### PR TITLE
Don't strip leading 'f' and 'e' from git-refs, using TrimPrefix instead of TrimLeft

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,13 +39,13 @@ func NewVersionInfo(parsefrom []string, imageID string) *VersionInfo {
 	var appver, gitref, builtby string
 	for _, p := range parsefrom {
 		if strings.HasPrefix(p, "App-Version: ") {
-			appver = strings.TrimSpace(strings.TrimLeft(p, "App-Version: "))
+			appver = strings.TrimSpace(strings.TrimPrefix(p, "App-Version: "))
 		}
 		if strings.HasPrefix(p, "Git-Ref: ") {
-			gitref = strings.TrimSpace(strings.TrimLeft(p, "Git-Ref: "))
+			gitref = strings.TrimSpace(strings.TrimPrefix(p, "Git-Ref: "))
 		}
 		if strings.HasPrefix(p, "Built-By: ") {
-			builtby = strings.TrimSpace(strings.TrimLeft(p, "Built-By: "))
+			builtby = strings.TrimSpace(strings.TrimPrefix(p, "Built-By: "))
 		}
 	}
 	v := &VersionInfo{


### PR DESCRIPTION
Also use it elsewhere, since it's the intended behavior in general.

This should get rid of the bug where git sha1s starting with 'e' and 'f' have that character (or characters) stripped.
